### PR TITLE
Dev/thermal

### DIFF
--- a/examples/tutorial1.jl
+++ b/examples/tutorial1.jl
@@ -50,32 +50,32 @@ The function [`DataFrame`](@ref) returns a `DataFrame` with all materials and th
 It might be useful to add other conductor materials with corrected properties based on recognized standards [cigre531](@cite) [IEC60287](@cite).
 =#
 
-copper_corrected = Material(1.835e-8, 1.0, 0.999994, 20.0, 0.00393) # Copper with corrected resistivity from IEC 60287-3-2
+copper_corrected = Material(1.835e-8, 1.0, 0.999994, 20.0, 0.00393, 401.0) # Copper with corrected resistivity from IEC 60287-3-2
 add!(materials, "copper_corrected", copper_corrected)
-aluminum_corrected = Material(3.03e-8, 1.0, 0.999994, 20.0, 0.00403) # Aluminum with corrected resistivity from IEC 60287-3-2
+aluminum_corrected = Material(3.03e-8, 1.0, 0.999994, 20.0, 0.00403, 237.0) # Aluminum with corrected resistivity from IEC 60287-3-2
 add!(materials, "aluminum_corrected", aluminum_corrected)
-lead = Material(21.4e-8, 1.0, 0.999983, 20.0, 0.00400) # Lead or lead alloy
+lead = Material(21.4e-8, 1.0, 0.999983, 20.0, 0.00400, 35.0) # Lead or lead alloy
 add!(materials, "lead", lead)
-steel = Material(13.8e-8, 1.0, 300.0, 20.0, 0.00450) # Steel
+steel = Material(13.8e-8, 1.0, 300.0, 20.0, 0.00450, 50.0) # Steel
 add!(materials, "steel", steel)
-bronze = Material(3.5e-8, 1.0, 1.0, 20.0, 0.00300) # Bronze
+bronze = Material(3.5e-8, 1.0, 1.0, 20.0, 0.00300, 60.0) # Bronze
 add!(materials, "bronze", bronze)
-stainless_steel = Material(70.0e-8, 1.0, 500.0, 20.0, 0.0) # Stainless steel
+stainless_steel = Material(70.0e-8, 1.0, 500.0, 20.0, 0.0, 16.0) # Stainless steel
 add!(materials, "stainless_steel", stainless_steel)
 
 #=
 When modeling cables for EMT analysis, one might be concerned with the impact of insulators and semiconductive layers on cable constants. Common insulation materials and semicons with different dielectric properties are reported in Table 6 of [cigre531](@cite). Let us include some of these materials in the [`MaterialsLibrary`](@ref) to help our future selves.
 =#
 
-epr = Material(1e15, 3.0, 1.0, 20.0, 0.005) # EPR (ethylene propylene rubber)
+epr = Material(1e15, 3.0, 1.0, 20.0, 0.005, 0.25) # EPR (ethylene propylene rubber)
 add!(materials, "epr", epr)
-pvc = Material(1e15, 8.0, 1.0, 20.0, 0.1) # PVC (polyvinyl chloride)
+pvc = Material(1e15, 8.0, 1.0, 20.0, 0.1, 0.19) # PVC (polyvinyl chloride)
 add!(materials, "pvc", pvc)
-laminated_paper = Material(1e15, 2.8, 1.0, 20.0, 0.0) # Laminated paper propylene
+laminated_paper = Material(1e15, 2.8, 1.0, 20.0, 0.0, 0.20) # Laminated paper propylene
 add!(materials, "laminated_paper", laminated_paper)
-carbon_pe = Material(0.06, 1e3, 1.0, 20.0, 0.0) # Carbon-polyethylene compound (semicon)
+carbon_pe = Material(0.06, 1e3, 1.0, 20.0, 0.0, 0.35) # Carbon-polyethylene compound (semicon)
 add!(materials, "carbon_pe", carbon_pe)
-conductive_paper = Material(18.5, 8.6, 1.0, 20.0, 0.0) # Conductive paper layer (semicon)
+conductive_paper = Material(18.5, 8.6, 1.0, 20.0, 0.0, 0.30) # Conductive paper layer (semicon)
 add!(materials, "conductive_paper", conductive_paper)
 
 # ##  Removing materials

--- a/examples/tutorial2.jl
+++ b/examples/tutorial2.jl
@@ -386,7 +386,7 @@ The earth return path significantly affects cable impedance calculations and nee
 
 # Define a frequency-dependent earth model (1 Hz to 1 MHz):
 f = 10.0 .^ range(0, stop = 6, length = 10)  # Frequency range
-earth_params = EarthModel(f, 100.0, 10.0, 1.0)  # 100 Ω·m resistivity, εr=10, μr=1
+earth_params = EarthModel(f, 100.0, 10.0, 1.0,0.0)  # 100 Ω·m resistivity, εr=10, μr=1
 
 # Earth model base (DC) properties:
 earthmodel_df = DataFrame(earth_params)

--- a/examples/tutorial3.jl
+++ b/examples/tutorial3.jl
@@ -36,11 +36,11 @@ set_backend!(:gl); #hide
 
 # Initialize library and the required materials for this design:
 materials = MaterialsLibrary(add_defaults = true)
-lead = Material(21.4e-8, 1.0, 0.999983, 20.0, 0.00400) # Lead or lead alloy
+lead = Material(21.4e-8, 1.0, 0.999983, 20.0, 0.00400,35) # Lead or lead alloy
 add!(materials, "lead", lead)
-steel = Material(13.8e-8, 1.0, 300.0, 20.0, 0.00450) # Steel
+steel = Material(13.8e-8, 1.0, 300.0, 20.0, 0.00450,50) # Steel
 add!(materials, "steel", steel)
-pp = Material(1e15, 2.8, 1.0, 20.0, 0.0) # Laminated paper propylene
+pp = Material(1e15, 2.8, 1.0, 20.0, 0.0,0.22) # Laminated paper propylene
 add!(materials, "pp", pp)
 
 # Inspect the contents of the materials library:
@@ -246,7 +246,7 @@ Define a constant frequency earth model:
 =#
 
 f = [1e-3] # Near DC frequency for the analysis
-earth_params = EarthModel(f, 100.0, 10.0, 1.0)  # 100 Ω·m resistivity, εr=10, μr=1
+earth_params = EarthModel(f, 100.0, 10.0, 1.0,0.0)  # 100 Ω·m resistivity, εr=10, μr=1
 
 # Earth model base (DC) properties:
 earthmodel_df = DataFrame(earth_params)
@@ -342,7 +342,6 @@ opts = (
 F = FormulationSet(:FEM,
 	impedance = Darwin(),
 	admittance = Electrodynamics(),
-	ehem_formula = EnforceLayer(3),
 	domain_radius = domain_radius,
 	domain_radius_inf = domain_radius * 1.25,
 	elements_per_length_conductor = 1,


### PR DESCRIPTION
This PR fixes incorrect usage of the Material constructor in tutorials.

The constructor requires 6 arguments, but only 5 were provided in some examples, causing runtime errors. The missing thermal conductivity parameter has been added.

This ensures tutorials 1, 2, and 3 run correctly. 